### PR TITLE
#6_0_不要なファイルを作らないための記述を追記

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,19 @@ module Myapp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.generators do |g|
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.template_engine false
+      g.test_framework :rspec,
+                        fixtures: true,
+                        view_spec: false,
+                        routing_specs: false,
+                        helper_specs: false,
+                        controller_specs: false,
+                        request_specs: true
+    end
   end
 end


### PR DESCRIPTION
application.rb に以下の記述を追記

`config.generators do |g|
      g.javascripts false
      g.stylesheets false
      g.helper false
      g.template_engine false
      g.test_framework :rspec,
                        fixtures: true,
                        view_spec: false,
                        routing_specs: false,
                        helper_specs: false,
                        controller_specs: false,
                        request_specs: true
    end`